### PR TITLE
Fix AMI image

### DIFF
--- a/IaC/ec2instance.yaml
+++ b/IaC/ec2instance.yaml
@@ -2,7 +2,7 @@ Resources:
   MyEC2Instance:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: ami-0ed83e7a78a23014e
+      ImageId: ami-0453ec754f44f9a4a
       InstanceType: t2.micro
       Tags:
         - Key: stage


### PR DESCRIPTION
A bug was found in the EC2 deployment because the AMI image for the micro instance required UEFI and the micro EC2 instance did not support it. AMI was changed to a supported one.

Closes #20 